### PR TITLE
Remove unnecessary component scan annotations

### DIFF
--- a/src/main/java/com/atomis/RestServiceApplication.java
+++ b/src/main/java/com/atomis/RestServiceApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@ComponentScan
 public class RestServiceApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
`@ComponentScan` annotations are not necessary on `@SpringBootApplication` classes as they are inherited